### PR TITLE
Rename deprecated import

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install @logux/redux
 See [documentation] for Logux API.
 
 ```js
-import createLoguxCreator from 'logux-redux/create-logux-creator'
+import createLoguxCreator from '@logux/redux/create-logux-creator'
 
 import log from '@logux/client/log'
 


### PR DESCRIPTION
Or maybe even destructured?
Haven't tested this, just the package name seems to be outdated