### PR TITLE
Add default generics to the LoguxStoreCreator.

### DIFF
--- a/create-logux-creator/index.d.ts
+++ b/create-logux-creator/index.d.ts
@@ -123,7 +123,7 @@ export interface LoguxStoreCreator {
     reducer: Reducer<S, A>,
     enhancer?: StoreEnhancer<Ext, StateExt>
   ): LoguxStore<S & StateExt, A> & ReduxStore<S & StateExt, A> & Ext
-  <S, A extends Action, Ext, StateExt>(
+  <S, A extends Action, Ext = {}, StateExt = {}>(
     reducer: Reducer<S, A>,
     preloadedState?: PreloadedState<S>,
     enhancer?: StoreEnhancer<Ext>


### PR DESCRIPTION
Typo in typings for LoguxStoreCreator — for an overloaded signature, the default values for generics are omitted.