### PR TITLE
Return the ClientMeta from dispath.sync.

### DIFF
--- a/create-logux-creator/index.js
+++ b/create-logux-creator/index.js
@@ -254,7 +254,7 @@ function createLoguxCreator (config = { }) {
 
       if (action.type === 'logux/processed') {
         if (processing[action.id]) {
-          processing[action.id][0]()
+          processing[action.id][0](meta)
           delete processing[action.id]
         }
       } else if (!meta.noAutoReason) {


### PR DESCRIPTION
In typings the all dispatch methods must return ClientMeta, but dispatch.sync [return void](https://github.com/logux/redux/blob/master/create-logux-creator/index.d.ts#L35).

To ensure consistency with other methods and the contract with typings, I also return it from dispatch.sync its meta.