### PR TITLE
Fix eternal false loading indication after changing `channels` argument

### DIFF
--- a/use-subscription/index.js
+++ b/use-subscription/index.js
@@ -49,6 +49,7 @@ function useSubscription (channels, opts = {}) {
 
   useEffect(() => {
     let ignoreResponce = false
+    changeSubscribing(true)
     add(store, subscriptions).then(() => {
       if (!ignoreResponce) changeSubscribing(false)
     })

--- a/use-subscription/index.test.ts
+++ b/use-subscription/index.test.ts
@@ -277,6 +277,15 @@ it('reports about subscription end', async () => {
     await delay(1)
   })
   expect(childProps(component, 0).isSubscribing).toBe(false)
+  act(() => {
+    click(component, 3)
+  })
+  expect(childProps(component, 0).isSubscribing).toBe(true)
+  await act(async () => {
+    log.add({ type: 'logux/processed', id: `7 ${nodeId} 0` })
+    await delay(1)
+  })
+  expect(childProps(component, 0).isSubscribing).toBe(false)
 })
 
 it('works on channels size changes', () => {


### PR DESCRIPTION
Fix logux/logux#59