### PR TITLE
Use new undo api

### DIFF
--- a/create-logux-creator/index.d.ts
+++ b/create-logux-creator/index.d.ts
@@ -19,7 +19,9 @@ import { Log } from '@logux/core'
 export type LoguxUndoAction = {
   type: 'logux/undo'
   id: string
+  action: Action
   reason?: string
+  [key: string]: any
 }
 
 export type LoguxUndoError = Error & {

--- a/create-logux-creator/index.d.ts
+++ b/create-logux-creator/index.d.ts
@@ -16,18 +16,6 @@ import {
 import { Unsubscribe } from 'nanoevents'
 import { Log } from '@logux/core'
 
-export type LoguxUndoAction = {
-  type: 'logux/undo'
-  id: string
-  action: Action
-  reason?: string
-  [key: string]: any
-}
-
-export type LoguxUndoError = Error & {
-  action: LoguxUndoAction
-}
-
 export interface LoguxDispatch<A extends Action> {
   <T extends A>(action: T): T
 

--- a/create-logux-creator/index.test.ts
+++ b/create-logux-creator/index.test.ts
@@ -246,7 +246,11 @@ it('undoes actions', async () => {
   ])
   expect(store.getState().value).toEqual('0abc')
   store.dispatch.crossTab(
-    { type: 'logux/undo', id: `2 ${nodeId} 0` },
+    {
+      type: 'logux/undo',
+      id: `2 ${nodeId} 0`,
+      action: { type: 'ADD', value: 'b' }
+    },
     { reasons: ['test'] }
   )
   await delay(1)
@@ -471,7 +475,7 @@ it('copies reasons to undo action', async () => {
   let nodeId = store.client.nodeId
   await store.dispatch.crossTab(ADD_A, { reasons: ['a', 'b'] })
   await store.dispatch.crossTab(
-    { type: 'logux/undo', id: `1 ${nodeId} 0` },
+    { type: 'logux/undo', id: `1 ${nodeId} 0`, action: ADD_A },
     { reasons: [] }
   )
   let result = await store.log.byId(`2 ${nodeId} 0`)
@@ -578,7 +582,11 @@ it('applies old actions from store', async () => {
       { id: '0 10:x 5', reasons: ['test'], tab: 'test2' }
     ),
     store1.dispatch.crossTab(
-      { type: 'logux/undo', id: '0 10:x 2' },
+      {
+        type: 'logux/undo',
+        id: '0 10:x 2',
+        action: { type: 'ADD', value: '2' }
+      },
       { id: '0 10:x 6', reasons: ['test'] }
     )
   ])
@@ -677,7 +685,11 @@ it('emits change event', async () => {
 
 it('warns about undoes cleaned action', async () => {
   let store = createStore(history)
-  await store.dispatch.crossTab({ type: 'logux/undo', id: '1 t 0' })
+  await store.dispatch.crossTab({
+    type: 'logux/undo',
+    id: '1 t 0',
+    action: { type: 'ADD' }
+  })
   expect(store.log.actions()).toHaveLength(0)
 })
 

--- a/create-logux-creator/index.test.ts
+++ b/create-logux-creator/index.test.ts
@@ -1,15 +1,18 @@
+import {
+  ClientMeta,
+  ClientOptions,
+  LoguxUndoAction,
+  LoguxUndoError
+} from '@logux/client'
 import { applyMiddleware, Reducer, StoreEnhancer } from 'redux'
 import { TestPair, TestTime, Action, TestLog } from '@logux/core'
-import { ClientMeta, ClientOptions } from '@logux/client'
 import { delay } from 'nanodelay'
 
 import {
   createLoguxCreator,
   createStoreCreator,
   LoguxReduxOptions,
-  LoguxUndoAction,
-  CrossTabClient,
-  LoguxUndoError
+  CrossTabClient
 } from '../index.js'
 
 type State = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,7 @@ export {
   createLoguxCreator,
   createStoreCreator,
   LoguxReduxStore,
-  LoguxReduxOptions,
-  LoguxUndoAction,
-  LoguxUndoError
+  LoguxReduxOptions
 } from './create-logux-creator/index.js'
 export { useSubscription, Channel } from './use-subscription/index.js'
 export { useDispatch } from './use-dispatch/index.js'


### PR DESCRIPTION
Part of logux/logux#52

Removes `LoguxUndoAction` and `LoguxUndoError` types and imports its from `@logux/client`. Tests will be passed after `@logux/client` update: logux/client#56