### PR TITLE
fix: do not process actions that have already been included in a replay

### DIFF
--- a/create-store-creator/index.test.ts
+++ b/create-store-creator/index.test.ts
@@ -357,6 +357,30 @@ test('replays history for reason-less action', async () => {
   equal(store.log.entries().length, 3)
 })
 
+test('does not accidentally re-process actions that were part of the latest replay', async () => {
+  let pair = new TestPair()
+  let store = createStore(history, { server: pair.left })
+
+  store.dispatch({ type: 'ADD', value: 'a' })
+  store.dispatch({ type: 'ADD', value: 'b' })
+
+  let localDispatch = store.dispatch.sync(
+    { type: 'ADD', value: 'c' },
+    { reasons: ['test'] }
+  )
+  // pair.left.emitter.emit('message', [
+  //   'sync',
+  //   { type: 'ADD', value: '|' },
+  //   { reasons: ['test'] }
+  // ])
+  await localDispatch
+  is(1, 2)
+  // await delay(1)
+  equal(store.getState().value, '0ab')
+  // equal(store.getState().value, '0a|c')
+  // equal(store.log.entries().length, 3)
+})
+
 test('replays actions before staring since initial state', async () => {
   let onMissedHistory = spy()
   let store = createStore(history, {

--- a/create-store-creator/index.test.ts
+++ b/create-store-creator/index.test.ts
@@ -358,22 +358,7 @@ test('replays history for reason-less action', async () => {
 })
 
 test('does not re-process actions that occurred in replay', async () => {
-  let pair = new TestPair()
-  let store = createStore(
-    (state: State, action: Action): State => {
-      if (isAdd(action)) {
-        let end = Date.now() + 1
-        while (end > Date.now()) {
-          // do nothing
-        }
-
-        return { value: `${state.value}${action.value}` }
-      } else {
-        return state
-      }
-    },
-    { server: pair.left }
-  )
+  let store = createStore()
 
   store.dispatch({ type: 'ADD', value: 'a' })
   store.dispatch.sync({ type: 'ADD', value: 'b' }, { reasons: ['test'] })

--- a/create-store-creator/index.test.ts
+++ b/create-store-creator/index.test.ts
@@ -357,7 +357,7 @@ test('replays history for reason-less action', async () => {
   equal(store.log.entries().length, 3)
 })
 
-test('does not accidentally re-process actions that were part of the latest replay', async () => {
+test('does not re-process actions that occurred in replay', async () => {
   let pair = new TestPair()
   let store = createStore(
     (state: State, action: Action): State => {

--- a/typings/logux__core.d.ts
+++ b/typings/logux__core.d.ts
@@ -1,0 +1,7 @@
+import { Emitter } from 'nanoevents'
+
+declare module '@logux/core' {
+  interface Connection {
+    emitter: Emitter
+  }
+}

--- a/typings/logux__core.d.ts
+++ b/typings/logux__core.d.ts
@@ -1,7 +1,0 @@
-import { Emitter } from 'nanoevents'
-
-declare module '@logux/core' {
-  interface Connection {
-    emitter: Emitter
-  }
-}


### PR DESCRIPTION
# Context

I work for a company that uses logux as a framework for building multiplayer experiences (https://voiceflow.com) and as we built out our solution we discovered a pretty nasty bug that occurs only when interleaving actions dispatched with `dispatch` with those using `dispatch.sync` which results in a replay that breaks the state.

With the help of some [debugging tools we created](https://github.com/voiceflow/logux-devtool) we were able to determine that during the replay one of the actions was effectively being processed twice which led to a corrupted state.

Here you can see the action `node.REMOVE_MANY` appearing twice in a row, upon inspection it is the same action with the same `meta.id`.
<img width="1722" alt="Screen Shot 2022-07-28 at 4 18 18 AM" src="https://user-images.githubusercontent.com/3784470/181457051-8339a159-4af4-4d99-a022-952980b56c6b.png">

# Edge Case

Conveniently the edge-case is described nicely by the test I wrote to validate the fix, so I'll use it for this example. Basically the replay occurred at a time when unprocessed actions had already been added to the log which resulted in a single action being processed twice in a row which corrupts the state.

```ts
store.dispatch({ type: 'ADD', value: 'a' })
equal(store.getState().value, '0a')

// this action is added to the log but not processed immediately
store.dispatch.sync({ type: 'ADD', value: 'b' }, { reasons: ['test'] })

// adding this action forces a state where replay must occur for 'b' and 'd'
store.dispatch({ type: 'ADD', value: 'c' })

// this action is added to the log but not processed because a replay is active
store.dispatch.sync({ type: 'ADD', value: 'd' }, { reasons: ['test'] })

/**
 * action 'b' is processed which results in a replay that includes action 'd'
 * action 'd' is queued and once the replay is done it is processed
 */
await delay(1)

/**
 * because action 'd' was in the log it is part of the replay
 * however it was processed again once the replay was complete
 * resulting in it being added twice
 */
equal(store.getState().value, '0abcdd')
```

# Solution

I toyed around with a couple of different solutions:
* excluding unprocessed actions from the scope of a replay
* adding something to `meta` to indicate that processing should be skipped

In the end I decided on re-using the `wait` lookup which is what is used for queuing in the first place.
If an action gets processed by a replay then the relevant `wait` entry is deleted. This works nicely with the existing logic so that when an action is done waiting for a replay it will skip processing if it is no longer in the `wait` lookup.
