### PR TITLE
fix: undo didchange condition

### DIFF
--- a/create-store-creator/index.js
+++ b/create-store-creator/index.js
@@ -194,10 +194,9 @@ export function createStoreCreator(client, options = {}) {
         if (wait[meta.id]) {
           delete wait[meta.id]
           await process(action, meta)
-          return true
         }
 
-        return false
+        return
       }
 
       if (action.type === 'logux/undo') {
@@ -225,8 +224,6 @@ export function createStoreCreator(client, options = {}) {
           }
         }
       }
-
-      return true
     }
 
     let lastAdded = 0
@@ -249,10 +246,8 @@ export function createStoreCreator(client, options = {}) {
 
       if (!meta.dispatch) {
         let prevState = store.getState()
-        process(action, meta).then(didChange => {
-          if (didChange) {
-            emitter.emit('change', store.getState(), prevState, action, meta)
-          }
+        process(action, meta).then(() => {
+          emitter.emit('change', store.getState(), prevState, action, meta)
         })
       }
     })


### PR DESCRIPTION
I spoke with @effervescentia about this fix on https://github.com/logux/redux/pull/46

All that mattered was the `wait` and `delete wait[id]`.
The boolean `return` and the `didChange` was more of an optimization.

However if `didChange` is false, we might miss an action that we've added and never get back a `'change'` event emitted.

It seems like there's nowhere in `logux` itself that listens for the `'change'` event, but we've actually found it necessary to listen for it to enable a "partialSync":

```
export const createPartialSync =
  (store: Store) =>
  <T extends AnyAction>(action: T) =>
    new Promise<ClientMeta>((resolve) => {
      const meta: Record<string, any> = { sync: true };
      // this will mutate meta and add "id"
      store.log.add(action, meta);

      const unbind = store.on('change', (_state, _prevState, _action, changeMeta) => {
        if (meta.id === changeMeta.id) {
          resolve(meta);
          unbind();
        }
      });
    });
```